### PR TITLE
node-http-watch-pipeline-activity to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: node-http
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: node-http-watch-pipeline-activity
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote node-http-watch-pipeline-activity to version 0.0.1